### PR TITLE
Specified Type Added Safe Asterisk Emulation

### DIFF
--- a/projects/asterisk/service/asterisk.service
+++ b/projects/asterisk/service/asterisk.service
@@ -3,6 +3,7 @@ Description=Asterisk PBX And Telephony Daemon
 After=network.target
 
 [Service]
+Type=simple
 User=asterisk
 Group=asterisk
 Environment=HOME=/var/lib/asterisk
@@ -10,6 +11,10 @@ WorkingDirectory=/var/lib/asterisk
 ExecStart=/usr/sbin/asterisk -f -C /etc/asterisk/asterisk.conf
 ExecStop=/usr/sbin/asterisk -rx 'core stop now'
 ExecReload=/usr/sbin/asterisk -rx 'core reload'
+
+Restart=on-failure
+RestartSec=10
+RestartPreventExitStatus=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I added safe_asterisk emulation to this unit since no other good source seems to exist for an Asterisk Unit. Tested and working on CentOS 7. `core stop gracefully` works while a `kill -9` will spawn an auto restart.
